### PR TITLE
switched to python3.6 + generic g++ command

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
-g++-6 -I/usr/local/include -I/usr/include/python2.7 -fpic -o eeg.o -c eeg_reader.cpp
-g++-6  -std=c++11 -shared -Wl,-soname,"libeeg.so" -L/usr/local/lib eeg.o -lboost_python -fpic -o openeeg.so
+g++ -I/usr/local/include -I/usr/include/python3.6m -fpic -o eeg.o -c eeg_reader.cpp
+g++  -std=c++11 -shared -Wl,-soname,"libeeg.so" -L/usr/local/lib eeg.o -lboost_python36 -fpic -o openeeg.so

--- a/processor.py
+++ b/processor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3.6
 import datetime
 import openeeg
 import pyqtgraph as pg


### PR DESCRIPTION
python 2 is eol
i suppose g++-6 is long time obsolete, not on my system

Signed-off-by: Miroslav Šulc <fordfrog@fordfrog.com>